### PR TITLE
Have a minimal style-guide with references

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,10 @@ Run the unit tests in the `merlict_development_kit` directory to ensure your bui
 cd ..
 ./build/merlict-test
 ```
+
+## style
+- 80 columns limit
+- whitespaces instead of tabulators
+- [cpplint](https://github.com/cpplint/cpplint) for C++
+- [google's C++ styleguide](https://google.github.io/styleguide/cppguide.html) for e.g. naming
+- [pycodestyle](https://pypi.org/project/pycodestyle/) for python


### PR DESCRIPTION
I list the style-guide rules which I tried to use in the merlict-project.
Its nothing fancy, no custom settings for the linters. Simple and wide-spread.